### PR TITLE
remove api-nodes.txt

### DIFF
--- a/mainnet/api-nodes.txt
+++ b/mainnet/api-nodes.txt
@@ -1,2 +1,0 @@
-https://akash.c29r3.xyz:443/api
-https://api.akash.smartnodes.one


### PR DESCRIPTION
From my understanding this is completely deprecated at this point, so there is no reason to advertise it.

The replacement is rest-over-grpc (haven't even confirmed that works) or use the tendermint RPC API that most of us are using anyways